### PR TITLE
ci: add S3 + CloudFront deploy workflow

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,80 @@
+name: Deploy Frontend (S3 + CloudFront)
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: eu-west-2
+  # SSM parameter path prefix owned by the serverless infra (Terraform is the sole writer)
+  SSM_PREFIX: /word-manager
+
+jobs:
+  deploy:
+    name: Build & deploy static site
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: vite-frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: vite-frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v5.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-session-name: github-actions-fe-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve infra config from SSM
+        id: config
+        run: |
+          BUCKET=$(aws ssm get-parameter --name "${SSM_PREFIX}/frontend/bucket_name" --query Parameter.Value --output text)
+          DIST_ID=$(aws ssm get-parameter --name "${SSM_PREFIX}/frontend/cloudfront_distribution_id" --query Parameter.Value --output text)
+          DOMAIN=$(aws ssm get-parameter --name "${SSM_PREFIX}/frontend/cloudfront_domain_name" --query Parameter.Value --output text)
+          echo "bucket=$BUCKET" >> "$GITHUB_OUTPUT"
+          echo "distribution_id=$DIST_ID" >> "$GITHUB_OUTPUT"
+          echo "domain=$DOMAIN" >> "$GITHUB_OUTPUT"
+
+      - name: Sync hashed assets (immutable, long cache)
+        run: |
+          aws s3 sync dist "s3://${{ steps.config.outputs.bucket }}" \
+            --delete \
+            --cache-control "public,max-age=31536000,immutable" \
+            --exclude "index.html"
+
+      - name: Upload index.html (no-cache)
+        run: |
+          aws s3 cp dist/index.html "s3://${{ steps.config.outputs.bucket }}/index.html" \
+            --cache-control "no-cache"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ steps.config.outputs.distribution_id }}" \
+            --paths "/index.html" "/"
+
+      - name: Smoke test
+        run: |
+          echo "Checking https://${{ steps.config.outputs.domain }}/"
+          curl -fsS -o /dev/null "https://${{ steps.config.outputs.domain }}/"


### PR DESCRIPTION
## Summary
Adds an automated deploy pipeline that ships the Vite frontend to S3 + CloudFront on every push to `main`. This is a new, dedicated static-site path — the existing `publish-image.yml` (ECR/Docker) is left untouched.

## What it does
1. Builds `vite-frontend/` with Node 22 (`npm ci && npm run build` → `dist/`).
2. Authenticates to AWS via GitHub OIDC (assumes the serverless deploy role).
3. Reads the target S3 bucket, CloudFront distribution id, and domain from SSM Parameter Store (`/word-manager/*`) — no hardcoded infra values.
4. Syncs hashed assets with a long immutable cache, uploads `index.html` as `no-cache`, invalidates `/index.html` + `/`, then smoke-tests the CloudFront URL.

## Notes
- No app code changes needed — the frontend already calls the relative `/api` prefix, which CloudFront proxies to API Gateway.
- Set repo secret **`AWS_DEPLOY_ROLE_ARN`** to the `github-actions-serverless-deploy` role ARN (distinct from the existing `AWS_ROLE_ARN` used for ECR). The role trust and SSM parameters are provisioned by full-stack-k8s#7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)